### PR TITLE
Adding parameter for optional OpenCover filters

### DIFF
--- a/docs/usage-example.md
+++ b/docs/usage-example.md
@@ -33,14 +33,16 @@ The unit tests are usually run with the build, but there are often integration a
 Note this stage does not generate coverage report as the type of tests run here are generally not worth reporting test coverage on.
 
 ### Code Coverage Filters ###
-By default, code coverage will be run on everything with the exception of assemblies ending in 'Test' or 'Tests'. This can be extended to exclude other files by passing a 'CodeCoverageFilters' property in the build.ps1 file
+By default, code coverage will be run on everything with the exception of assemblies ending in 'Test' or 'Tests'. This can be extended to exclude other files by passing a 'CodeCoverageFilter' property in the build.ps1 file.
+
 ```
 .\packages\psake.4.3.2\tools\psake.ps1 .\packages\Kaiseki.1.0.5\tools\Load-Modules.ps1 -properties @{
     "TestCategory" = "Unit",
-    "CodeCoverageFilters" = "-[Company.Web]*HelpPage*"
+    "CodeCoverageFilter" = "-[*Tests]* -[*Test]* -[Company.Web]*HelpPage*"
 }
 ```
-The example above will exclude 'HelpPage' classes in the Company.Web module (for example, to exclude the files brought in from [WebApi HelpPage](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.HelpPage). The filters format follows the convention for [OpenCover filters](https://github.com/opencover/opencover/wiki/Usage#user-content-understanding-filters) and gets passed as a command line argument
+
+The example above will exclude the default Test modules as well as any 'HelpPage' classes in the Company.Web module (for example, to exclude the files brought in from [WebApi HelpPage](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.HelpPage). The filters format follows the convention for [OpenCover filters](https://github.com/opencover/opencover/wiki/Usage#user-content-understanding-filters) and gets passed as a command line argument
 
 ### Deployment - YEEHAWWWWWW!!!! ###
 ```

--- a/docs/usage-example.md
+++ b/docs/usage-example.md
@@ -32,6 +32,16 @@ The unit tests are usually run with the build, but there are often integration a
 ```
 Note this stage does not generate coverage report as the type of tests run here are generally not worth reporting test coverage on.
 
+### Code Coverage Filters ###
+By default, code coverage will be run on everything with the exception of assemblies ending in 'Test' or 'Tests'. This can be extended to exclude other files by passing a 'CodeCoverageFilters' property in the build.ps1 file
+```
+.\packages\psake.4.3.2\tools\psake.ps1 .\packages\Kaiseki.1.0.5\tools\Load-Modules.ps1 -properties @{
+    "TestCategory" = "Unit",
+    "CodeCoverageFilters" = "-[Company.Web]*HelpPage*"
+}
+```
+The example above will exclude 'HelpPage' classes in the Company.Web module (for example, to exclude the files brought in from [WebApi HelpPage](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.HelpPage). The filters format follows the convention for [OpenCover filters](https://github.com/opencover/opencover/wiki/Usage#user-content-understanding-filters) and gets passed as a command line argument
+
 ### Deployment - YEEHAWWWWWW!!!! ###
 ```
 .\CiArtefact\kkm-defaults\Deploy-WebDeploy.ps1 -target dev-iis.contoso.net -username user -password pass -xmlsuffix dev

--- a/src/Tools/Tasks-Testing.ps1
+++ b/src/Tools/Tasks-Testing.ps1
@@ -23,7 +23,7 @@ function Get-TestAssemblies {
 properties {
     $TestProjectFilter = ".*Test.*"
     $TestCategory = "Unit"
-    $CodeCoverageFilters = ""
+    $CodeCoverageFilter = "-[*Tests]* -[*Test]*"
 }
 task Execute-Nunit -depends Get-TargetSolution -precondition {
     Write-Host ?Execute-Nunit?
@@ -68,7 +68,7 @@ task Execute-Nunit -depends Get-TargetSolution -precondition {
 	if ($assemblyInclusionPrefix -eq "") {
 		$assemblyInclusionPrefix = $solutionName.Substring(0, $solutionName.Length - 4)
 	}
-    $filterInnerArg = "+[" + $assemblyInclusionPrefix + "*]* -[*Tests]* -[*Test]* " + $CodeCoverageFilters
+    $filterInnerArg = "+[" + $assemblyInclusionPrefix + "*]* " + $CodeCoverageFilter
     $filterArg = "-filter:$filterInnerArg"
 
     $targetArg = "-target:$((Resolve-Path $nunitBinPath.FullName -Relative).Replace('.\', ''))"

--- a/src/Tools/Tasks-Testing.ps1
+++ b/src/Tools/Tasks-Testing.ps1
@@ -23,6 +23,7 @@ function Get-TestAssemblies {
 properties {
     $TestProjectFilter = ".*Test.*"
     $TestCategory = "Unit"
+    $CodeCoverageFilters = ""
 }
 task Execute-Nunit -depends Get-TargetSolution -precondition {
     Write-Host ?Execute-Nunit?
@@ -67,7 +68,7 @@ task Execute-Nunit -depends Get-TargetSolution -precondition {
 	if ($assemblyInclusionPrefix -eq "") {
 		$assemblyInclusionPrefix = $solutionName.Substring(0, $solutionName.Length - 4)
 	}
-    $filterInnerArg = "+[" + $assemblyInclusionPrefix + "*]* -[*Tests]* -[*Test]*"
+    $filterInnerArg = "+[" + $assemblyInclusionPrefix + "*]* -[*Tests]* -[*Test]* " + $CodeCoverageFilters
     $filterArg = "-filter:$filterInnerArg"
 
     $targetArg = "-target:$((Resolve-Path $nunitBinPath.FullName -Relative).Replace('.\', ''))"


### PR DESCRIPTION
Allows for more accurate CodeCoverage reports by allowing you to filter what is included. For example, the WebAPI Help Pages adds a ton of code that I don't want included in the report.